### PR TITLE
Reduce win32 compiler warnings

### DIFF
--- a/src/AboutDlg/AboutDialog.h
+++ b/src/AboutDlg/AboutDialog.h
@@ -29,10 +29,10 @@ class AboutDialog : public StaticDialog
 public:
 	AboutDialog() : StaticDialog() {};
 
-	void init(HINSTANCE hInst, NppData nppData)
+	void init(HINSTANCE hInst, NppData nppDataParam)
 	{
-		_nppData = nppData;
-		Window::init(hInst, nppData._nppHandle);
+		_nppData = nppDataParam;
+		Window::init(hInst, nppDataParam._nppHandle);
 	};
 
 	void doDialog();

--- a/src/Compare.cpp
+++ b/src/Compare.cpp
@@ -2508,7 +2508,7 @@ extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode)
 }
 
 
-extern "C" __declspec(dllexport) LRESULT messageProc(UINT Message, WPARAM, LPARAM)
+extern "C" __declspec(dllexport) LRESULT messageProc(UINT, WPARAM, LPARAM)
 {
 	return TRUE;
 }

--- a/src/Engine/diff.h
+++ b/src/Engine/diff.h
@@ -95,6 +95,8 @@ public:
 
 	std::vector<diff_edit> operator()();
 
+	DiffCalc& operator=(const DiffCalc&) = delete;
+
 private:
 	struct middle_snake {
 		int x, y, u, v;

--- a/src/NppHelpers.cpp
+++ b/src/NppHelpers.cpp
@@ -58,7 +58,7 @@ HWND NppToolbarHandleGetter::get()
 }
 
 
-BOOL CALLBACK NppToolbarHandleGetter::enumWindowsCB(HWND hwnd, LPARAM lParam)
+BOOL CALLBACK NppToolbarHandleGetter::enumWindowsCB(HWND hwnd, LPARAM )
 {
 	TCHAR winClassName[64];
 

--- a/src/SettingsDlg/SettingsDialog.h
+++ b/src/SettingsDlg/SettingsDialog.h
@@ -34,10 +34,10 @@ class SettingsDialog : public StaticDialog
 public:
 	SettingsDialog() : StaticDialog() {};
 
-	void init(HINSTANCE hInst, NppData nppData)
+	void init(HINSTANCE hInst, NppData nppDataParam)
 	{
-		_nppData = nppData;
-		Window::init(hInst, nppData._nppHandle);
+		_nppData = nppDataParam;
+		Window::init(hInst, nppDataParam._nppHandle);
 	};
 
 	UINT doDialog(UserSettings* settings);

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -51,7 +51,7 @@ void DelayedWork::cancel()
 }
 
 
-VOID CALLBACK DelayedWork::timerCB(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
+VOID CALLBACK DelayedWork::timerCB(HWND, UINT, UINT_PTR idEvent, DWORD)
 {
 	std::map<UINT_PTR, DelayedWork*>::iterator it = workMap.find(idEvent);
 

--- a/src/Tools.h
+++ b/src/Tools.h
@@ -39,6 +39,8 @@ struct ScopedIncrementer
 		--_useCount;
 	}
 
+	ScopedIncrementer& operator=(const ScopedIncrementer&) = delete;
+
 private:
 	volatile unsigned&	_useCount;
 };


### PR DESCRIPTION
- avoid VS2015 win32 warnings:

"C:\projects\compare-plugin\projects\2013\Compare.vcxproj" (default target) (1) ->
(ClCompile target) ->
  ..\..\src\Tools.cpp(54): warning C4100: 'dwTime': unreferenced formal parameter [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  ..\..\src\Tools.cpp(54): warning C4100: 'uMsg': unreferenced formal parameter [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  ..\..\src\Tools.cpp(54): warning C4100: 'hwnd': unreferenced formal parameter [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  c:\projects\compare-plugin\src\settingsdlg\SettingsDialog.h(37): warning C4459: declaration of 'nppData' hides global declaration (compiling source file ..\..\src\SettingsDlg\SettingsDialog.cpp) [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  C:\projects\compare-plugin\src\AboutDlg\AboutDialog.h(32): warning C4459: declaration of 'nppData' hides global declaration (compiling source file ..\..\src\Compare.cpp) [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  C:\projects\compare-plugin\src\SettingsDlg\SettingsDialog.h(37): warning C4459: declaration of 'nppData' hides global declaration (compiling source file ..\..\src\Compare.cpp) [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  ..\..\src\Compare.cpp(2511): warning C4100: 'Message': unreferenced formal parameter [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  ..\..\src\NppHelpers.cpp(61): warning C4100: 'lParam': unreferenced formal parameter [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]

-  avoid VS2013 win32 compiler warnings:

  c:\projects\compare-plugin\src\Tools.h(44): warning C4512: 'ScopedIncrementer' : assignment operator could not be generated (..\..\src\Compare.cpp) [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  C:\projects\compare-plugin\src\Engine\diff.h(117): warning C4512: 'DiffCalc<unsigned int>' : assignment operator could not be generated (..\..\src\Compare.cpp) [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  ..\..\src\Compare.cpp(2511): warning C4100: 'Message' : unreferenced formal parameter [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]
  c:\projects\compare-plugin\src\engine\diff.h(117): warning C4512: 'DiffCalc<Word>' : assignment operator could not be generated (..\..\src\Engine\Engine.cpp) [C:\projects\compare-plugin\projects\2013\Compare.vcxproj]